### PR TITLE
Add --no_collapse option

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,11 @@ Options:
 
 --help | -h         Display this message and exit.
 
+--no_collapse       By default, lists will be formatted as space-separated
+                    values on the same line as much as possible. This option
+                    disables this behavior and causes lists to always appear
+                    with one item per line.
+
 --no_fix_include    By default, if an #include directive references a file
                     name with the .inc extension, the file name will appear
                     in the YAML output with the extension changed to

--- a/index.js
+++ b/index.js
@@ -27,6 +27,10 @@ const parseArgsOptions = {
         short: 'h',
         default: false
     },
+    'no_collapse': {
+        type: 'boolean',
+        default: false
+    },
     'no_fix_include': {
         type: 'boolean',
         default: false
@@ -77,6 +81,11 @@ Options:
                     the 'aerleon.yml' config file.
 
 --help | -h         Display this message and exit.
+
+--no_collapse       By default, lists will be formatted as space-separated
+                    values on the same line as much as possible. This option
+                    disables this behavior and causes lists to always appear
+                    with one item per line.
 
 --no_fix_include    By default, if an #include directive references a file
                     name with the .inc extension, the file name will appear

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,7 +7,7 @@ import { glob } from 'glob';
 
 import loadConfig from './config.js';
 import DefinitionFile, { DefinitionFileType } from './defs.js';
-import PolicyFile from "./policy.js";
+import PolicyFile, { PolicyFormatOptions } from "./policy.js";
 import SanityCheck, { ErrorStage } from './sanity_check.js';
 
 
@@ -24,6 +24,7 @@ export default async function pol2yaml(_posargs, options) {
     const {
         base_directory = config.base_directory,
         definitions_directory = config.definitions_directory,
+        no_collapse,
         no_fix_include,
         output_directory = '.',
         sanity_check
@@ -42,6 +43,7 @@ export default async function pol2yaml(_posargs, options) {
         await pol2yamlInner({
             base_directory,
             definitions_directory,
+            no_collapse,
             no_fix_include,
             output_directory
         }, sanity_checker);
@@ -62,6 +64,7 @@ export default async function pol2yaml(_posargs, options) {
 async function pol2yamlInner({
     base_directory,
     definitions_directory,
+    no_collapse,
     no_fix_include,
     output_directory
 }, sanity_checker) {
@@ -123,7 +126,8 @@ async function pol2yamlInner({
                 case '.pol':
                     const is_include = '.inc' === extname;
                     const fix_include_names = !no_fix_include;
-                    target.yaml = (new PolicyFile(text, { is_include, fix_include_names })).toYAML();
+                    const format_lists = no_collapse ? PolicyFormatOptions.LISTS_SPLAY : PolicyFormatOptions.LISTS_COLLAPSE;
+                    target.yaml = (new PolicyFile(text, { is_include, fix_include_names, format_lists })).toYAML();
                     break;
                 case '.net':
                 case '.svc':
@@ -134,6 +138,7 @@ async function pol2yamlInner({
 
         } catch (e) {
             console.warn(`WARNING: pol2yaml failed to parse "${target.path}"`);
+            console.warn(e);
             // e.message is not very helpful, antlr4 parser already generates warning lines
             if (sanity_checker) {
                 sanity_checker.addError(ErrorStage.PARSE, target.path, e);

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -5,6 +5,7 @@ import PolicyLexer from '../antlr/PolicyLexer.js';
 import PolicyParser from '../antlr/PolicyParser.js';
 import { Document, visit } from 'yaml';
 
+import Enum from './enum.js';
 import PolicyParseTreeVisitor from './visitor.js';
 import { IncludeTerm } from './visitor.js';
 
@@ -68,14 +69,19 @@ function PolicyFile_replace_includes(policy_file) {
     }
 }
 
-function PolicyFile_parse(policy_file, text) {
+function PolicyFile_parse(policy_file, text, options) {
     const lexer = new PolicyLexer(new CharStream(text));
     const parser = new PolicyParser(new CommonTokenStream(lexer));
 
     const tree = policy_file.is_include ? parser.term_list_only() : parser.policy();
 
-    const visitor = new PolicyParseTreeVisitor();
+    const visitor = new PolicyParseTreeVisitor(options);
     return visitor.visit(tree);
+}
+
+export class PolicyFormatOptions extends Enum {
+    static LISTS_COLLAPSE = new PolicyFormatOptions('LISTS_COLLAPSE');
+    static LISTS_SPLAY = new PolicyFormatOptions('LISTS_SPLAY');
 }
 
 export default class PolicyFile {
@@ -83,12 +89,13 @@ export default class PolicyFile {
     fix_include_names = true
     contents = null
 
-    constructor(text, { is_include = false, fix_include_names = true } = {}) {
+    constructor(text, { is_include = false, fix_include_names = true, format_lists = PolicyFormatOptions.LISTS_COLLAPSE } = {}) {
         this.is_include = is_include;
         this.fix_include_names = fix_include_names;
+        this.options = { format_lists };
 
         text = PolicyFile_preprocess_includes(text);
-        this.contents = PolicyFile_parse(this, text);
+        this.contents = PolicyFile_parse(this, text, this.options);
         PolicyFile_replace_includes(this);
     }
 

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -2,6 +2,7 @@ import Enum from './enum.js';
 import PolicyParser from '../antlr/PolicyParser.js';
 import PolicyVisitor from '../antlr/PolicyVisitor.js';
 
+import { PolicyFormatOptions } from './policy.js';
 
 // Model
 export class Filter {
@@ -205,13 +206,16 @@ function collate(rules) {
 }
 
 // collapse lists
-// - most lists should be collapsed
-// - some lists cannot be collapsed
-// - long lists should not be collapsed
 // - map/append types have 2nd-level lists
-function collapse(rules) {
+function collapse(rules, { format_lists } = {}) {
 
-    const collapse = list => list.join(' ');
+    const collapser_collapse = list => list.join(' ');
+    const collapser_splay = list => {
+        if (list.length > 1) {
+            return list;
+        }
+        return list.join(' ');
+    }
 
     for (const rule_key in rules) {
         const rule = rules[rule_key];
@@ -221,17 +225,23 @@ function collapse(rules) {
             continue;
         }
 
+        // format_lists controls which collapser style to use
+        // some lists should always be collapsed (target)
+        const collapser = rule.type[2]?.always_collapse || format_lists === PolicyFormatOptions.LISTS_COLLAPSE ?
+            collapser_collapse :
+            collapser_splay;
+
         // special case for list of tuples
         if (rule.type[2]?.tuple_list) {
 
             rule.data = rule.data.map(tuple => `(${tuple[0]},${tuple[1]})`);
         } else if (Array.isArray(rule.data)) {
-            rule.data = collapse(rule.data);
+            rule.data = collapser(rule.data);
 
             // collapse each inner list
         } else if (rule.type[2]?.map && collation !== JoinType.PLATFORM_STRING_CONCAT) {
             for (const platform in rule.data) {
-                rule.data[platform] = collapse(rule.data[platform]);
+                rule.data[platform] = collapser(rule.data[platform]);
             }
         }
     }
@@ -304,6 +314,12 @@ function visitTopLevel(ctx) {
 }
 
 export default class PolicyParseTreeVisitor extends PolicyVisitor {
+
+    constructor(options) {
+        super();
+        this.options = options;
+    }
+
     visitPolicy(ctx) {
         return visitTopLevel.call(this, ctx);
     }
@@ -366,7 +382,7 @@ export default class PolicyParseTreeVisitor extends PolicyVisitor {
     visitRule_list(ctx) {
         const child_productions = this.visitChildren(ctx);
         const rules = collate(child_productions);
-        collapse(rules);
+        collapse(rules, this.options);
         return rules;
     }
 
@@ -546,5 +562,5 @@ export class RuleType extends Enum {
     static PORT_MIRROR = new RuleType("PORT_MIRROR", "port-mirror", { "join_type": JoinType.LAST_WINS })
     static SZONE = new RuleType("SZONE", "source-zone")
     static DZONE = new RuleType("DZONE", "destination-zone")
-    static TARGET = new RuleType("TARGET", "target", { "join_type": JoinType.PLATFORM_FIRST_WINS, "map": true, "yaml_key": "targets" })
+    static TARGET = new RuleType("TARGET", "target", { "join_type": JoinType.PLATFORM_FIRST_WINS, "map": true, "yaml_key": "targets", "always_collapse": true })
 }

--- a/tests/test_pol_collapse.yaml.ref
+++ b/tests/test_pol_collapse.yaml.ref
@@ -1,0 +1,15 @@
+filters:
+  - header:
+      targets:
+        paloalto: from-zone internal to-zone external
+        srx: from-zone internal to-zone external
+      option:
+        - tcp-established
+    terms:
+      - name: test-tcp-udp-many-mixed
+        comment: |-
+          Testing mixed IPv4 and IPv6 IPs to test address books.
+        source-address: MANY_IPV4 MANY_IPV6
+        destination-address: MANY_IPV4 MANY_IPV6
+        protocol: tcp udp
+        action: accept

--- a/tests/test_pol_splay.yaml.ref
+++ b/tests/test_pol_splay.yaml.ref
@@ -1,0 +1,21 @@
+filters:
+  - header:
+      targets:
+        paloalto: from-zone internal to-zone external
+        srx: from-zone internal to-zone external
+      option:
+        - tcp-established
+    terms:
+      - name: test-tcp-udp-many-mixed
+        comment: |-
+          Testing mixed IPv4 and IPv6 IPs to test address books.
+        source-address:
+          - MANY_IPV4
+          - MANY_IPV6
+        destination-address:
+          - MANY_IPV4
+          - MANY_IPV6
+        protocol:
+          - tcp
+          - udp
+        action: accept


### PR DESCRIPTION
This flag will splay out data lists instead of collapsing lists into a space-separated string as shown below.

https://github.com/aerleon/pol2yaml/blob/256ba912dc5c9b2538231a3ac7b8e87dbccbaa54/tests/test_pol_splay.yaml.ref#L1-L21